### PR TITLE
Signal that local-allocator has restarted using suspend/resume

### DIFF
--- a/localConfig
+++ b/localConfig
@@ -1,8 +1,6 @@
 (
  (socket socket)
  (port 8081)
- (remoteHost 127.0.0.1)
- (remotePort 4000)
  (allocation_quantum 16)
  (localJournal localJournal)
  (freePool host1-free)


### PR DESCRIPTION
Xenvmd resends the free LV when it sees the FromLVM queue has
suspended and resumed. This avoids the need for the local allocator
to remember the set of free blocks over crash/restart, and avoids
using the network interface -- suspend and resume is communicated
entirely via the storage.

Signed-off-by: David Scott dave.scott@citrix.com

This needs [mirage/shared-block-ring#20]
