### PR TITLE
Add dependency on bisect, a code coverage library

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -14,7 +14,7 @@ Library xenvmidl
   Path:               idl
   Findlibname:        xenvmidl
   Modules:            Xenvm_interface, Xenvm_client, Log
-  BuildDepends:       rpclib, rpclib.syntax, lvm, cohttp.lwt, threads
+  BuildDepends:       rpclib, rpclib.syntax, lvm, cohttp.lwt, threads, bisect
 
 Executable "xenvmd"
   ByteOpt:            -warn-error +a
@@ -24,7 +24,7 @@ Executable "xenvmd"
   MainIs:             xenvmd.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, mirage-block-unix, devmapper, threads, lvm, cstruct, oUnit, io-page, io-page.unix, cmdliner, sexplib.syntax, xenvmidl, lvm, lvm.mapper, shared-block-ring
+  BuildDepends:       lwt, lwt.unix, mirage-block-unix, devmapper, threads, lvm, cstruct, oUnit, io-page, io-page.unix, cmdliner, sexplib.syntax, xenvmidl, lvm, lvm.mapper, shared-block-ring, bisect
 
 Executable "xenvm"
   ByteOpt:            -warn-error +a

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: c17f235c7d2da1ca81c6eb35abe2338d)
+# DO NOT EDIT (digest: d79bbfe858d521ebb09708d168d1ccce)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -20,6 +20,7 @@ true: annot, bin_annot
 <idl/*.ml{,i,y}>: oasis_library_xenvmidl_byte
 <idl/xenvmidl.{cma,cmxa}>: oasis_library_xenvmidl_native
 <idl/*.ml{,i,y}>: oasis_library_xenvmidl_native
+<idl/*.ml{,i,y}>: pkg_bisect
 <idl/*.ml{,i,y}>: pkg_cohttp.lwt
 <idl/*.ml{,i,y}>: pkg_lvm
 <idl/*.ml{,i,y}>: pkg_rpclib
@@ -30,6 +31,7 @@ true: annot, bin_annot
 <xenvmd/*.ml{,i,y}>: oasis_executable_xenvmd_byte
 <xenvmd/xenvmd.{native,byte}>: oasis_executable_xenvmd_native
 <xenvmd/*.ml{,i,y}>: oasis_executable_xenvmd_native
+<xenvmd/xenvmd.{native,byte}>: pkg_bisect
 <xenvmd/xenvmd.{native,byte}>: pkg_cmdliner
 <xenvmd/xenvmd.{native,byte}>: pkg_cohttp.lwt
 <xenvmd/xenvmd.{native,byte}>: pkg_cstruct
@@ -48,6 +50,7 @@ true: annot, bin_annot
 <xenvmd/xenvmd.{native,byte}>: pkg_shared-block-ring
 <xenvmd/xenvmd.{native,byte}>: pkg_threads
 <xenvmd/xenvmd.{native,byte}>: use_xenvmidl
+<xenvmd/*.ml{,i,y}>: pkg_bisect
 <xenvmd/*.ml{,i,y}>: pkg_cmdliner
 <xenvmd/*.ml{,i,y}>: pkg_cohttp.lwt
 <xenvmd/*.ml{,i,y}>: pkg_cstruct
@@ -72,6 +75,7 @@ true: annot, bin_annot
 <xenvm/*.ml{,i,y}>: oasis_executable_xenvm_byte
 <xenvm/xenvm.{native,byte}>: oasis_executable_xenvm_native
 <xenvm/*.ml{,i,y}>: oasis_executable_xenvm_native
+<xenvm/xenvm.{native,byte}>: pkg_bisect
 <xenvm/xenvm.{native,byte}>: pkg_cmdliner
 <xenvm/xenvm.{native,byte}>: pkg_cohttp.lwt
 <xenvm/xenvm.{native,byte}>: pkg_devmapper
@@ -84,6 +88,7 @@ true: annot, bin_annot
 <xenvm/xenvm.{native,byte}>: pkg_rpclib.syntax
 <xenvm/xenvm.{native,byte}>: pkg_threads
 <xenvm/xenvm.{native,byte}>: use_xenvmidl
+<xenvm/*.ml{,i,y}>: pkg_bisect
 <xenvm/*.ml{,i,y}>: pkg_cmdliner
 <xenvm/*.ml{,i,y}>: pkg_cohttp.lwt
 <xenvm/*.ml{,i,y}>: pkg_devmapper
@@ -102,6 +107,7 @@ true: annot, bin_annot
 <*.ml{,i,y}>: oasis_executable_local_allocator_byte
 <local_allocator.{native,byte}>: oasis_executable_local_allocator_native
 <*.ml{,i,y}>: oasis_executable_local_allocator_native
+<local_allocator.{native,byte}>: pkg_bisect
 <local_allocator.{native,byte}>: pkg_cmdliner
 <local_allocator.{native,byte}>: pkg_cohttp.lwt
 <local_allocator.{native,byte}>: pkg_cstruct
@@ -120,6 +126,7 @@ true: annot, bin_annot
 <local_allocator.{native,byte}>: pkg_shared-block-ring
 <local_allocator.{native,byte}>: pkg_threads
 <local_allocator.{native,byte}>: use_xenvmidl
+<*.ml{,i,y}>: pkg_bisect
 <*.ml{,i,y}>: pkg_cmdliner
 <*.ml{,i,y}>: pkg_cohttp.lwt
 <*.ml{,i,y}>: pkg_cstruct

--- a/idl/META
+++ b/idl/META
@@ -1,8 +1,8 @@
 # OASIS_START
-# DO NOT EDIT (digest: b2837ae80939dc7073d496721eb047e8)
+# DO NOT EDIT (digest: 1f376ca99279109e33c85ff4f6d307f1)
 version = "0.1"
 description = "Simple thin LVHD tools"
-requires = "rpclib rpclib.syntax lvm cohttp.lwt threads"
+requires = "rpclib rpclib.syntax lvm cohttp.lwt threads bisect"
 archive(byte) = "xenvmidl.cma"
 archive(byte, plugin) = "xenvmidl.cma"
 archive(native) = "xenvmidl.cmxa"

--- a/opam
+++ b/opam
@@ -17,4 +17,5 @@ depends: [
   "shared-block-ring"
   "devmapper"
   "cmdliner"
+  "bisect"
 ]

--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,10 @@ set -e
 rm -f bigdisk
 dd if=/dev/zero of=bigdisk bs=1 seek=16G count=0
 losetup /dev/loop0 bigdisk
-./xenvm.native format /dev/loop0 --vg djstest
-./xenvmd.native --daemon
+BISECT_FILE=xenvm.coverage ./xenvm.native format /dev/loop0 --vg djstest
+BISECT_FILE=xenvmd.coverage ./xenvmd.native &
+
+export BISECT_FILE=xenvm.coverage
 
 ./xenvm.native create --lv live
 ./xenvm.native activate --lv live `pwd`/djstest-live /dev/loop0
@@ -20,6 +22,8 @@ for i in ${LVS}; do
   echo Activating $i
   ./xenvm.native activate --lv $i `pwd`/djstest-$i /dev/loop0
 done
+
+./xenvm.native shutdown
 
 echo Run 'sudo ./local_allocator.native' and type 'djstest-live' to request an allocation
 echo Run './cleanup.sh' to remove all volumes and devices


### PR DESCRIPTION
Note that this requires a bit more work to extract info. Notably,
the setup.sh script doesn't exit, as 'xenvm.native shutdown' hangs

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
