### PR TITLE
test: add workaround for bisect/ocveralls vector subscript issue

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 set -e
 
 eval `opam config env`
+opam pin add ocveralls git://github.com/djs55/ocveralls#fix-vector-combine -y
 make
 
 # Making a 1G disk


### PR DESCRIPTION
See [sagotch/ocveralls#4]

Signed-off-by: David Scott dave.scott@citrix.com
