### PR TITLE
Add a pvs command

### DIFF
--- a/xenvm/pvs.ml
+++ b/xenvm/pvs.ml
@@ -1,0 +1,63 @@
+(* LVM compatible bits and pieces *)
+
+open Cmdliner
+open Xenvm_common
+open Lwt
+
+let default_fields = [
+ "pv_name";
+ "vg_name";
+ "pv_fmt";
+ "pv_attr";
+ "pv_size";
+ "pv_free";
+]
+open Lvm
+module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock)
+
+let (>>*=) m f = match m with
+  | `Error (`Msg e) -> fail (Failure e)
+  | `Error (`DuplicateLV x) -> fail (Failure (Printf.sprintf "%s is a duplicate LV name" x))
+  | `Error (`OnlyThisMuchFree x) -> fail (Failure (Printf.sprintf "There is only %Ld free" x))
+  | `Error (`UnknownLV x) -> fail (Failure (Printf.sprintf "I couldn't find an LV named %s" x))
+  | `Ok x -> f x
+
+let (>>|=) m f = m >>= fun x -> x >>*= f
+
+let with_block filename f =
+  let open Lwt in
+  Block.connect filename
+  >>= function
+  | `Error _ -> fail (Failure (Printf.sprintf "Unable to read %s" filename))
+  | `Ok x ->
+    Lwt.catch (fun () -> f x) (fun e -> Block.disconnect x >>= fun () -> fail e)
+
+let pvs copts noheadings nosuffix units fields devices =
+  let open Xenvm_common in
+  Lwt_main.run (
+    let read device =
+      with_block device
+        (fun x ->
+          Vg_IO.connect [ x ] `RO >>|= fun vg ->
+          return vg 
+        ) in
+    Lwt_list.map_s read devices
+    >>= fun vgs ->
+    let do_row vg =
+      List.map (fun pv ->
+        row_of (vg,Some pv,None,None) nosuffix units fields)
+      vg.Lvm.Vg.pvs in
+    let headings = headings_of fields in
+    let rows = List.concat (List.map (fun vg -> do_row (Vg_IO.metadata_of vg)) vgs) in
+    print_table noheadings (" "::headings) (List.map (fun r -> " "::r) rows);
+    Lwt.return ()
+  )
+
+let pvs_cmd =
+  let doc = "report information about physical volumes" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "pvs produces formatted output about physical volumes";
+  ] in
+  Term.(pure pvs $ Xenvm_common.copts_t $ noheadings_arg $ nosuffix_arg $ units_arg $ output_arg default_fields $ Xenvm_common.devices_arg),
+  Term.info "pvs" ~sdocs:"COMMON OPTIONS" ~doc ~man

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -194,7 +194,7 @@ let filenames =
   Arg.(non_empty & pos_all file [] & info [] ~docv:"FILENAMES" ~doc)
 
 let filename =
-  let doc = "Path to the files" in
+  let doc = "Path to the file" in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"FILENAME" ~doc)
 
 let vgname =
@@ -332,6 +332,7 @@ let cmds = [
   set_vg_info_cmd;
   Vgcreate.vgcreate_cmd;
   Vgs.vgs_cmd;
+  Pvs.pvs_cmd;
   Lvremove.lvremove_cmd;
   Lvrename.lvrename_cmd;
 ]


### PR DESCRIPTION
./xenvm.native  pvs --noheadings --nosuffix --units b /dev/sda3
  pv0 VG_XenStorage-80fe81f8-273f-0a32-501b-dec42e85d821 lvm2 a--  241394778112 241239588864

./xenvm.native  pvs  /dev/sda3
  PV  VG                                                 Fmt  Attr PSize         PFree
  pv0 VG_XenStorage-80fe81f8-273f-0a32-501b-dec42e85d821 lvm2 a--  241394778112B 241239588864B

Limitations are:
- the PV name is printed and not resolved to a Linux device: real pvs prints "/dev/sda3"
- we don't actually perform unit conversion, so everything is in bytes

Related to #16 
