### PR TITLE
Erase metadata volumes which we create

### DIFF
--- a/idl/META
+++ b/idl/META
@@ -1,9 +1,9 @@
 # OASIS_START
-# DO NOT EDIT (digest: 798568431db55f5a6dcaff164adbe75d)
+# DO NOT EDIT (digest: c6b1ef075eec04a5c6fad660e74dad2f)
 version = "0.1"
 description = "LVM-like volume manager supporting thinly provisioned LVs"
 requires =
-"rpclib rpclib.syntax sexplib sexplib.syntax lvm cohttp.lwt threads bisect mirage-block-unix devmapper"
+"rpclib rpclib.syntax sexplib sexplib.syntax lvm cohttp.lwt threads mirage-block-unix devmapper bisect"
 archive(byte) = "xenvmidl.cma"
 archive(byte, plugin) = "xenvmidl.cma"
 archive(native) = "xenvmidl.cmxa"

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -70,7 +70,7 @@ let query_lvm config =
 module FromLVM = struct
   module R = Shared_block.Ring.Make(Log)(Vg_IO.Volume)(FreeAllocation)
   let rec attach ~disk () =
-    fatal_error "attaching to FromLVM queue" (R.Consumer.attach ~disk ()) 
+    fatal_error "attaching to FromLVM queue" (R.Consumer.attach ~queue:"FromLVM Consumer" ~client:"xenvm-local-allocator" ~disk ()) 
   let state t =
     fatal_error "querying FromLVM state" (R.Consumer.state t)
   let rec suspend t =
@@ -116,7 +116,7 @@ end
 module ToLVM = struct
   module R = Shared_block.Ring.Make(Log)(Vg_IO.Volume)(ExpandVolume)
   let rec attach ~disk () =
-    R.Producer.attach ~disk ()
+    R.Producer.attach ~queue:"ToLVM Producer" ~client:"xenvm-local-allocator" ~disk ()
     >>= function
     | `Ok x -> return x
     | _ ->


### PR DESCRIPTION
This is needed because the volumes may already have the correct
signature (e.g. from a previous run) but now contain stale data
which must be discarded.
- When host.create creates {to,from}LVM volumes, it explicitly
  erases them.
- Vgcreate erases the xenvmd journal volume

This relies on [mirage/mirage-block-volume#64]

Signed-off-by: David Scott dave.scott@citrix.com
