### PR TITLE
Fix bugs and make more robust

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library xenvmidl
   CompiledObject:     best
   Path:               idl
   Findlibname:        xenvmidl
-  Modules:            Xenvm_interface, Xenvm_client, Log, Result, Errors, ResizeRequest, ResizeResponse
+  Modules:            Xenvm_interface, Xenvm_client, Log, Result, Errors, ResizeRequest, ResizeResponse, Pidfile
   BuildDepends:       rpclib, rpclib.syntax, sexplib, sexplib.syntax, lvm, cohttp.lwt, threads, mirage-block-unix, devmapper, bisect
 
 Executable "xenvmd"

--- a/_oasis
+++ b/_oasis
@@ -13,7 +13,7 @@ Library xenvmidl
   CompiledObject:     best
   Path:               idl
   Findlibname:        xenvmidl
-  Modules:            Xenvm_interface, Xenvm_client, Log, Result, Errors, ResizeRequest
+  Modules:            Xenvm_interface, Xenvm_client, Log, Result, Errors, ResizeRequest, ResizeResponse
   BuildDepends:       rpclib, rpclib.syntax, sexplib, sexplib.syntax, lvm, cohttp.lwt, threads, mirage-block-unix, devmapper, bisect
 
 Executable "xenvmd"

--- a/idl/pidfile.ml
+++ b/idl/pidfile.ml
@@ -1,0 +1,14 @@
+(* We wish to ensure at-most-one copy of the program is started *)
+
+let write_pid pidfile =
+  let txt = string_of_int (Unix.getpid ()) in
+  try
+    let fd = Unix.openfile pidfile [ Unix.O_WRONLY; Unix.O_CREAT ] 0o0644 in
+    Unix.lockf fd Unix.F_TLOCK (String.length txt);
+    let (_: int) = Unix.write fd txt 0 (String.length txt) in
+    ()
+  with e ->
+    Printf.fprintf stderr "%s\n" (Printexc.to_string e);
+    Printf.fprintf stderr "The pidfile %s is locked: you cannot start the program twice!\n" pidfile;
+    Printf.fprintf stderr "If the process was shutdown cleanly then verify and remove the pidfile.\n%!";
+    exit 1

--- a/idl/resizeResponse.ml
+++ b/idl/resizeResponse.ml
@@ -1,0 +1,13 @@
+open Sexplib.Std
+
+module T = struct
+  type t =
+    | Device_mapper_device_does_not_exist of string
+    | Request_for_no_segments of int64
+    | Success
+  with sexp
+  (** Response from xenvm-local-allocator to xenvm *)
+end
+
+include SexpToCstruct.Make(T)
+include T

--- a/idl/xenvmidl.mldylib
+++ b/idl/xenvmidl.mldylib
@@ -1,9 +1,10 @@
 # OASIS_START
-# DO NOT EDIT (digest: d1d1ec0a025cbfc9d6a3157d3e0422d2)
+# DO NOT EDIT (digest: 10ee93a04fc3f517b71619e8ea26d853)
 Xenvm_interface
 Xenvm_client
 Log
 Result
 Errors
 ResizeRequest
+ResizeResponse
 # OASIS_STOP

--- a/idl/xenvmidl.mldylib
+++ b/idl/xenvmidl.mldylib
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 10ee93a04fc3f517b71619e8ea26d853)
+# DO NOT EDIT (digest: 57b376d9a9ea46b70acab11aab5f012c)
 Xenvm_interface
 Xenvm_client
 Log
@@ -7,4 +7,5 @@ Result
 Errors
 ResizeRequest
 ResizeResponse
+Pidfile
 # OASIS_STOP

--- a/idl/xenvmidl.mllib
+++ b/idl/xenvmidl.mllib
@@ -1,9 +1,10 @@
 # OASIS_START
-# DO NOT EDIT (digest: d1d1ec0a025cbfc9d6a3157d3e0422d2)
+# DO NOT EDIT (digest: 10ee93a04fc3f517b71619e8ea26d853)
 Xenvm_interface
 Xenvm_client
 Log
 Result
 Errors
 ResizeRequest
+ResizeResponse
 # OASIS_STOP

--- a/idl/xenvmidl.mllib
+++ b/idl/xenvmidl.mllib
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 10ee93a04fc3f517b71619e8ea26d853)
+# DO NOT EDIT (digest: 57b376d9a9ea46b70acab11aab5f012c)
 Xenvm_interface
 Xenvm_client
 Log
@@ -7,4 +7,5 @@ Result
 Errors
 ResizeRequest
 ResizeResponse
+Pidfile
 # OASIS_STOP

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -287,6 +287,8 @@ let main config daemon socket journal fromLVM toLVM =
     fromLVM = (match fromLVM with None -> config.Config.fromLVM | Some x -> x);
   } in
   debug "Loaded configuration: %s" (Sexplib.Sexp.to_string_hum (Config.sexp_of_t config));
+  Pidfile.write_pid (config.Config.socket ^ ".lock");
+
   if daemon then Lwt_daemon.daemonize ();
 
   let t =

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -287,9 +287,9 @@ let main config daemon socket journal fromLVM toLVM =
     fromLVM = (match fromLVM with None -> config.Config.fromLVM | Some x -> x);
   } in
   debug "Loaded configuration: %s" (Sexplib.Sexp.to_string_hum (Config.sexp_of_t config));
-  Pidfile.write_pid (config.Config.socket ^ ".lock");
-
   if daemon then Lwt_daemon.daemonize ();
+
+  Pidfile.write_pid (config.Config.socket ^ ".lock");
 
   let t =
     Device.read_sector_size config.Config.devices

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -278,7 +278,7 @@ let extend_volume device vg lv extents =
             (Lvm.Pv.Name.to_string pvname);
           next_sector, segments, targets
       ) (next_sector, [], []) extents in
-   segments, targets
+   List.rev segments, List.rev targets
 
 let stat x =
   match Devmapper.stat x with

--- a/xenvmd/xenvmd.ml
+++ b/xenvmd/xenvmd.ml
@@ -618,6 +618,13 @@ let run port sock_path config daemon =
   let config = { config with Config.listenPort = match port with None -> config.Config.listenPort | Some x -> x } in
   let config = { config with Config.listenPath = match sock_path with None -> config.Config.listenPath | Some x -> Some x } in
   if daemon then Lwt_daemon.daemonize ();
+  ( match config.Config.listenPath with
+    | None ->
+      (* don't need a lock file because we'll fail to bind to the port *)
+      ()
+    | Some path ->
+      info "Writing pidfile to %s" path;
+      Pidfile.write_pid (path ^ ".lock") );
   let t =
     info "Started with configuration: %s" (Sexplib.Sexp.to_string_hum (Config.sexp_of_t config));
     VolumeManager.vgopen ~devices:config.Config.devices


### PR DESCRIPTION
bugs:
- always round up to the nearest extent
- local allocation is synchronous with error reporting

robustness:
- use lock files to prevent multiple instances of the daemons being started
