### PR TITLE
vgs: read stats directly from the disk

### DIFF
--- a/xenvm/pvs.ml
+++ b/xenvm/pvs.ml
@@ -15,23 +15,6 @@ let default_fields = [
 open Lvm
 module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock)
 
-let (>>*=) m f = match m with
-  | `Error (`Msg e) -> fail (Failure e)
-  | `Error (`DuplicateLV x) -> fail (Failure (Printf.sprintf "%s is a duplicate LV name" x))
-  | `Error (`OnlyThisMuchFree x) -> fail (Failure (Printf.sprintf "There is only %Ld free" x))
-  | `Error (`UnknownLV x) -> fail (Failure (Printf.sprintf "I couldn't find an LV named %s" x))
-  | `Ok x -> f x
-
-let (>>|=) m f = m >>= fun x -> x >>*= f
-
-let with_block filename f =
-  let open Lwt in
-  Block.connect filename
-  >>= function
-  | `Error _ -> fail (Failure (Printf.sprintf "Unable to read %s" filename))
-  | `Ok x ->
-    Lwt.catch (fun () -> f x) (fun e -> Block.disconnect x >>= fun () -> fail e)
-
 let pvs copts noheadings nosuffix units fields devices =
   let open Xenvm_common in
   Lwt_main.run (

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -177,7 +177,7 @@ let benchmark copts (vg_name,_) =
     get_vg_info_t copts vg_name >>= fun info ->
     set_uri copts info;
     let mib = Int64.mul 1048576L 4L in
-    let number = 40000 in
+    let number = 1000 in
     let start = Unix.gettimeofday () in
     let rec fori acc f = function
     | 0 -> return acc

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -179,13 +179,15 @@ let benchmark copts (vg_name,_) =
     let mib = Int64.mul 1048576L 4L in
     let number = 1000 in
     let start = Unix.gettimeofday () in
-    let rec fori acc f = function
+    let rec fori test_name acc f = function
     | 0 -> return acc
     | n ->
       f n
       >>= fun () ->
-      fori ((number - n, Unix.gettimeofday () -. start) :: acc) f (n - 1) in
-    fori [] (fun i -> Client.create ~name:(Printf.sprintf "test-lv-%d" i) ~size:mib ~tags:[]) number
+      if ((n * 100) / number) <> (((n + 1) * 100) / number)
+      then Printf.fprintf stderr "%s %d %% complete\n%!" test_name (100 - (n * 100) / number);
+      fori test_name ((number - n, Unix.gettimeofday () -. start) :: acc) f (n - 1) in
+    fori "Creating volumes" [] (fun i -> Client.create ~name:(Printf.sprintf "test-lv-%d" i) ~size:mib ~tags:[]) number
     >>= fun creates ->
     let time = Unix.gettimeofday () -. start in
     let oc = open_out "benchmark.dat" in
@@ -193,7 +195,7 @@ let benchmark copts (vg_name,_) =
     Printf.fprintf oc "# %d creates in %.1f s\n" number time;
     Printf.fprintf oc "# Average %.1f /sec\n" (float_of_int number /. time);
     let start = Unix.gettimeofday () in
-    fori [] (fun i -> Client.remove ~name:(Printf.sprintf "test-lv-%d" i)) number
+    fori "Removing volumes" [] (fun i -> Client.remove ~name:(Printf.sprintf "test-lv-%d" i)) number
     >>= fun destroys ->
     let time = Unix.gettimeofday () -. start in
     List.iter (fun (n, t) -> Printf.fprintf oc "%d %f\n" (number + n) t) (List.rev destroys);


### PR DESCRIPTION
- test: decrease the length of the benchmark so it can run from travis
- read stats directly from the disk, so we can probe for volume groups without xenvmd

Signed-off-by: David Scott dave.scott@eu.citrix.com
