### PR TITLE
CP-12323: Integrate mock camldm with xenvm

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -103,7 +103,7 @@ let file_exists filename =
     true
   with Unix.Unix_error(Unix.ENOENT, _, _) -> false
 
-let dm_exists name = match Devmapper.stat name with
+let dm_exists name = match Devmapper.Linux.stat name with
   | None -> false
   | Some _ -> true
 

--- a/xenvm/lvchange.ml
+++ b/xenvm/lvchange.ml
@@ -10,6 +10,7 @@ let dev_path_of vg_name lv_name =
   Printf.sprintf "/dev/%s/%s" vg_name lv_name
 
 let activate vg lv local_device =
+  let module Devmapper = (val !Xenvm_common.dm: Devmapper.S.DEVMAPPER) in
   let path = dev_path_of vg.Lvm.Vg.name lv.Lvm.Lv.name in
   Lwt.catch (fun () -> Lwt_unix.mkdir (Filename.dirname path) 0x755) (fun _ -> Lwt.return ()) >>= fun () -> 
   Mapper.read [ local_device ]
@@ -41,6 +42,7 @@ let lvchange_activate copts vg_name lv_name physical_device =
   )
 
 let deactivate vg lv =
+  let module Devmapper = (val !Xenvm_common.dm : Devmapper.S.DEVMAPPER) in
   let open Xenvm_common in
   let name = Mapper.name_of vg lv in
   (* This can fail with an EBUSY *)
@@ -68,6 +70,7 @@ let deactivate vg lv =
   Client.flush ~name:lv.Lvm.Lv.name
 
 let reload vg lv local_device =
+  let module Devmapper = (val !Xenvm_common.dm : Devmapper.S.DEVMAPPER) in
   let open Xenvm_common in
   Mapper.read [ local_device ]
   >>= fun devices ->

--- a/xenvm/lvrename.ml
+++ b/xenvm/lvrename.ml
@@ -4,6 +4,7 @@ open Cmdliner
 open Lwt
 
 let lvrename copts (vg_name,lv_opt) newname physical_device =
+  let module Devmapper = (val !Xenvm_common.dm : Devmapper.S.DEVMAPPER) in
   let lv_name = match lv_opt with | Some l -> l | None -> failwith "Need an LV name" in
   (* It seems you can say "vg/lv" or "lv" *)
   let newname = match newname with

--- a/xenvm/lvresize.ml
+++ b/xenvm/lvresize.ml
@@ -4,6 +4,7 @@ open Cmdliner
 open Lwt
 
 let lvresize copts live (vg_name,lv_opt) real_size percent_size =
+  let module Devmapper = (val !Xenvm_common.dm : Devmapper.S.DEVMAPPER) in
   let lv_name = match lv_opt with | Some l -> l | None -> failwith "Need an LV name" in
   let open Xenvm_common in
   let size = match parse_size real_size percent_size with

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -84,6 +84,7 @@ let create config name size =
      Client.create ~name ~size:size_in_bytes ~tags:[])
 
 let activate config lvname path pv =
+  let module Devmapper = (val !Xenvm_common.dm : Devmapper.S.DEVMAPPER) in
   set_uri config None;
   Lwt_main.run
     (Client.get_lv ~name:lvname


### PR DESCRIPTION
Update the code to cope with the new camldm module hierarchy.

Add an argument `--mock-devmapper' to all subcommands of xenvm to
use the mock devmapper interfaces.

Signed-off-by: Kaifeng Zhu kaifeng.zhu@citrix.com
