### PR TITLE
test: pass through the environment to subprocesses

### DIFF
--- a/test/common.ml
+++ b/test/common.ml
@@ -131,7 +131,7 @@ let canonicalise x =
 
 exception Bad_exit of int * string * string list * string * string
 
-let run ?(env= [| |]) ?stdin cmd args =
+let run ?(env= Unix.environment()) ?stdin cmd args =
   let cmd = canonicalise cmd in
   debug "%s %s" cmd (String.concat " " args);
   let null = Unix.openfile "/dev/null" [ Unix.O_RDWR ] 0 in


### PR DESCRIPTION
This will include the BISECT_FILE variable, needed for bisect.

Signed-off-by: David Scott dave.scott@citrix.com
