### PR TITLE
Hook up both test suites to travis

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -5,7 +5,10 @@ eval `opam config env`
 export BISECT_FILE=_build/xenvm.coverage
 # Needed to support Unix domain sockets:
 sudo opam pin add conduit git://github.com/mirage/ocaml-conduit -y
+# run the OCaml test suite
 make test
+# run the bash test suite
+./setup.sh
 
 echo Generating bisect report-- this fails on travis
 (cd _build; bisect-report xenvm*.out -summary-only -html /vagrant/report/ || echo Ignoring bisect-report failure)

--- a/setup.sh
+++ b/setup.sh
@@ -30,10 +30,8 @@ else
 fi
 cat test.xenvmd.conf.in | sed -r "s|@BIGDISK@|$LOOP|g" > test.xenvmd.conf
 mkdir -p /tmp/xenvm.d
-BISECT_FILE=_build/xenvm.coverage ./xenvm.native format $LOOP --vg djstest --configdir /tmp/xenvm.d $MOCK_ARG
-BISECT_FILE=_build/xenvmd.coverage ./xenvmd.native --config ./test.xenvmd.conf --daemon
-
-export BISECT_FILE=_build/xenvm.coverage
+./xenvm.native format $LOOP --vg djstest --configdir /tmp/xenvm.d $MOCK_ARG
+./xenvmd.native --config ./test.xenvmd.conf --daemon
 
 ./xenvm.native set-vg-info --pvpath $LOOP -S /tmp/xenvmd djstest --local-allocator-path /tmp/xenvm-local-allocator --uri file://local/services/xenvmd/djstest --configdir /tmp/xenvm.d $MOCK_ARG
 

--- a/test.local_allocator.conf.in
+++ b/test.local_allocator.conf.in
@@ -1,7 +1,7 @@
 (
- (socket @HOST@-socket)
+ (socket /tmp/@HOST@-socket)
  (allocation_quantum 16)
- (localJournal localJournal)
+ (localJournal /tmp/@HOST@-localJournal)
  (devices (@BIGDISK@))
  (toLVM @HOST@-toLVM)
  (fromLVM @HOST@-fromLVM)


### PR DESCRIPTION
This extends the `setup.sh` suite to use the `--mock-devmapper` if not running as root (e.g. from travis)
