### PR TITLE
Make sure we truncate the pidfile when opening

### DIFF
--- a/idl/pidfile.ml
+++ b/idl/pidfile.ml
@@ -3,7 +3,7 @@
 let write_pid pidfile =
   let txt = string_of_int (Unix.getpid ()) in
   try
-    let fd = Unix.openfile pidfile [ Unix.O_WRONLY; Unix.O_CREAT ] 0o0644 in
+    let fd = Unix.openfile pidfile [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o0644 in
     Unix.lockf fd Unix.F_TLOCK (String.length txt);
     let (_: int) = Unix.write fd txt 0 (String.length txt) in
     ()


### PR DESCRIPTION
This avoids writing incorrect pids

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
