### PR TITLE
Add uncooperative disconnect

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -22,4 +22,4 @@ if [ "$USE_MOCK" -eq "0" ]; then
   losetup -d $LOOP
 fi
 
-rm -f localJournal bigdisk *.out*  djstest-* dm-mock
+rm -f localJournal bigdisk *.out*  djstest-* dm-mock xenvmd.log*

--- a/idl/xenvm_interface.ml
+++ b/idl/xenvm_interface.ml
@@ -69,7 +69,7 @@ module Host = struct
   (** [connect host] connects to existing metadata volumes and
       process them. *)
 
-  external disconnect: name:string -> unit = ""
+  external disconnect: cooperative:bool -> name:string -> unit = ""
   (** [disconnect host] disconnects from metadata volumes and
       stops processing them. *)
 

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -91,11 +91,11 @@ let host_connect copts (vg_name,_) host =
     set_uri copts info;
     Client.Host.connect host in
   Lwt_main.run t
-let host_disconnect copts (vg_name,_) host =
+let host_disconnect copts (vg_name,_) uncooperative host =
   let t =
     get_vg_info_t copts vg_name >>= fun info ->
     set_uri copts info;
-    Client.Host.disconnect host in
+    Client.Host.disconnect ~cooperative:(not uncooperative) ~name:host in
   Lwt_main.run t 
 let host_destroy copts (vg_name,_) host =
   let t =
@@ -232,12 +232,15 @@ let host_connect_cmd =
   Term.info "host-connect" ~sdocs:copts_sect ~doc ~man
 
 let host_disconnect_cmd =
-  let doc = "Disconnect to a host" in
+  let uncooperative_flag =
+    let doc = "Perform an uncooperative disconnect (if the host is dead)" in
+    Arg.(value & flag & info ["uncooperative"] ~doc) in
+  let doc = "Disconnect from a host" in
   let man = [
     `S "DESCRIPTION";
-    `P "Dergister a host with the daemon. The daemon will suspend the block queues and stop listening to requests.";
+    `P "Dergister a host with the daemon. The daemon will suspend the block queues (unless the --uncooperative flag is used) and stop listening to requests.";
   ] in
-  Term.(pure host_disconnect $ copts_t $ name_arg $ hostname),
+  Term.(pure host_disconnect $ copts_t $ name_arg $ uncooperative_flag $ hostname),
   Term.info "host-disconnect" ~sdocs:copts_sect ~doc ~man
 
 let host_create_cmd =

--- a/xenvm/xenvm_common.ml
+++ b/xenvm/xenvm_common.ml
@@ -249,8 +249,9 @@ let physical_device_arg_required =
 let parse_name name_arg =
   let comps = Stringext.split name_arg '/' in
   match comps with
-  | ["";"dev";vg;lv] -> (vg,Some lv)
+  | ["";"dev";vg;""]
   | ["";"dev";vg] -> (vg,None)
+  | ["";"dev";vg;lv] -> (vg,Some lv)
   | [vg;lv] -> (vg,Some lv)
   | [vg] -> (vg,None)
   | _ -> failwith "failed to parse vg name"


### PR DESCRIPTION
We want to be able to disconnect hosts that have actually died. This means we
cannot suspend the ToLVM queue for this host since suspending the ring is
a cooperative operation. Instead, we simply unmark the ring as connected and
remove the host from our table of connected hosts.
