### PR TITLE
CP-13469: Add upgrade/downgrade CLI support

### DIFF
--- a/test/common.ml
+++ b/test/common.ml
@@ -211,7 +211,7 @@ let tib = Int64.(gib * kib)
 
 module Client = Xenvm_client.Client
 
-let with_temp_file fn =
+let with_temp_file ?(delete=true) fn =
   let filename = Filename.concat (Unix.getcwd ()) "vg" in
   let f = Unix.openfile filename [Unix.O_CREAT; Unix.O_RDWR; Unix.O_TRUNC] 0o644 in
   (* approximately 10000 4MiB extents for volumes, 100MiB for metadata and
@@ -220,7 +220,7 @@ let with_temp_file fn =
   ignore(Unix.write f "\000" 0 1);
   Unix.close f;
   let result = fn filename in
-  Unix.unlink filename;
+  if delete then Unix.unlink filename;
   result
   (* NB we leak the file on error, but this is quite useful *)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -141,6 +141,8 @@ let upgrade =
 
         (* Downgrade the volume to lvm2 *)
         xenvm [ "downgrade"; "vg" ] |> ignore_string;
+        (* Check it's idempotent *)
+        xenvm [ "downgrade"; "vg" ] |> ignore_string;
 
         (* check the changing of the magic persisted *)
         Label_IO.read block >>:= fun label ->

--- a/test/test.ml
+++ b/test/test.ml
@@ -89,6 +89,7 @@ let pvremove =
     )
   )
 
+exception Could_not_obtain_lvm_lock
 let upgrade =
   "Check that we can upgrade an LVM volume to XenVM" >:: fun () ->
   with_temp_file (fun filename ->
@@ -114,31 +115,46 @@ let upgrade =
           ~printer:string_of_int 2 (LVs.cardinal (Vg_IO.metadata_of vg).Vg.lvs);
 
         (* Upgrade the volume to journalled *)
-        (* TODO: Take the LVM lock *)
-        (* Change the label magic to be Journalled to hide from LVM *)
-        let module Label_IO = Label.Make(Block) in
-        let (>>:=) m f = m >>= function `Ok x -> f x | `Error (`Msg e) -> fail (Failure e) in
-        Label_IO.read block >>:= fun label ->
-        let new_label_header = Label.Label_header.create `Journalled in
-        let new_label = {label with Label.label_header = new_label_header } in
-        Label_IO.write block new_label >>:= fun () ->
-        (* Create the redo log, first reconnect to pick up the label changes *)
-        Vg_IO.connect ~flush_interval:0. [ block ] `RW >>|= fun vg ->
-        let creation_host = Unix.gethostname () in
-        let creation_time = Unix.gettimeofday () |> Int64.of_float in
-        let size = Int64.(4L * mib) in
-        Vg.create (Vg_IO.metadata_of vg) Xenvm_interface._journal_name size
-          ~creation_host ~creation_time >>*= fun (_, op) ->
-        Vg_IO.update vg [ op ] >>|= fun () ->
-        Vg_IO.sync vg >>|= fun () ->
-        (* TODO: release the LVM lock *)
+        (* LVM locking code can be seen here:
+         * https://git.fedorahosted.org/cgit/lvm2.git/tree/lib/misc/lvm-flock.c#n141 *)
+        let with_lvm_lock vg_name f =
+          let lock_dir = "/run/lock/lvm" in
+          let lock_path = Filename.concat lock_dir ("V_" ^ vg_name ^ ":aux") in
+          Lwt.catch (fun () ->
+            mkdir_rec lock_dir 0o0700;
+            Lwt_unix.(openfile lock_path [O_CREAT; O_TRUNC; O_RDWR] 0o644)
+            >>= fun fd ->
+            Lwt_unix.(lockf fd F_LOCK) 0;
+          ) (function _ -> fail Could_not_obtain_lvm_lock) >>= fun () ->
+          Lwt.finalize f (fun () -> Lwt_unix.unlink lock_path) in
+        with_lvm_lock "vg" (fun () ->
+          (* Change the label magic to be Journalled to hide from LVM *)
+          let module Label_IO = Label.Make(Block) in
+          let (>>:=) m f = m >>= function `Ok x -> f x | `Error (`Msg e) -> fail (Failure e) in
+          Label_IO.read block >>:= fun label ->
+          let new_label_header = Label.Label_header.create `Journalled in
+          let new_label = {label with Label.label_header = new_label_header } in
+          Label_IO.write block new_label >>:= fun () ->
+          (* Create the redo log, first reconnect to pick up the label changes *)
+          Vg_IO.connect ~flush_interval:0. [ block ] `RW >>|= fun vg ->
+          let creation_host = Unix.gethostname () in
+          let creation_time = Unix.gettimeofday () |> Int64.of_float in
+          let size = Int64.(4L * mib) in
+          Vg.create (Vg_IO.metadata_of vg) Xenvm_interface._journal_name size
+            ~creation_host ~creation_time >>*= fun (_, op) ->
+          Vg_IO.update vg [ op ] >>|= fun () ->
+          Vg_IO.sync vg
+        ) >>|= fun () ->
 
         (* check the changing of the magic persisted *)
+        let module Label_IO = Label.Make(Block) in
+        let (>>:=) m f = m >>= function `Ok x -> f x | `Error (`Msg e) -> fail (Failure e) in
         Label_IO.read block >>:= fun label ->
         assert_equal ~msg:"PV label was not as expected"
           ~printer:(function None -> "" | Some m -> Sexplib.Sexp.to_string_hum (Magic.sexp_of_t m))
           (Some `Journalled) Label.(Label_header.magic_of label.label_header);
         (* Check we now have 1 more volume than before (the redo log) *)
+        Vg_IO.connect ~flush_interval:0. [ block ] `RO >>|= fun vg ->
         assert_equal ~msg:"Unexpected number of LVs on LVM after upgrade"
           ~printer:string_of_int 3 (LVs.cardinal (Vg_IO.metadata_of vg).Vg.lvs);
         (* Check xenvmd is happy to connect *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -75,17 +75,12 @@ let pvremove =
   (fun () ->
     with_temp_file (fun filename ->
       xenvm [ "vgcreate"; vg; filename ] |> ignore_string;
-      mkdir_rec "/tmp/xenvm.d" 0o0755;
-      xenvm [ "set-vg-info"; "--pvpath"; filename; "-S"; "/tmp/xenvmd"; vg; "--local-allocator-path"; "/tmp/xenvm-local-allocator"; "--uri"; "file://local/services/xenvmd/"^vg ] |> ignore_string;
       xenvm [ "vgs"; vg ] |> ignore_string;
       xenvm [ "pvremove"; filename ] |> ignore_string;
-      begin
-        try
-          xenvm [ "vgs"; vg ] |> ignore_string;
-          failwith "pvremove failed to hide a VG from vgs"
-        with Bad_exit(1, _, _, _, _) ->
-          ()
-      end
+      try
+        xenvm [ "vgs"; vg ] |> ignore_string;
+        failwith "pvremove failed to hide a VG from vgs"
+      with Bad_exit(1, _, _, _, _) -> ()
     )
   )
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -115,6 +115,8 @@ let upgrade =
 
         (* Upgrade the volume to journalled *)
         xenvm [ "upgrade"; "vg" ] |> ignore_string;
+        (* Check it's idempotent *)
+        xenvm [ "upgrade"; "vg" ] |> ignore_string;
 
         (* check the changing of the magic persisted *)
         let module Label_IO = Label.Make(Block) in

--- a/test/test.ml
+++ b/test/test.ml
@@ -293,6 +293,7 @@ let xenvmd_suite = "Commands which require xenvmd" >::: [
 ]
 
 let _ =
+  Random.self_init ();
   mkdir_rec "/tmp/xenvm.d" 0o0755;
   let check_results_with_exit_code results =
     if List.exists (function RFailure _ | RError _ -> true | _ -> false) results

--- a/test/test.ml
+++ b/test/test.ml
@@ -299,5 +299,8 @@ let xenvmd_suite = "Commands which require xenvmd" >::: [
 
 let _ =
   mkdir_rec "/tmp/xenvm.d" 0o0755;
-  run_test_tt_main no_xenvmd_suite |> ignore;
-  with_xenvmd (fun vg -> run_test_tt_main xenvmd_suite |> ignore);
+  let check_results_with_exit_code results =
+    if List.exists (function RFailure _ | RError _ -> true | _ -> false) results
+    then exit 1 in
+  run_test_tt_main no_xenvmd_suite |> check_results_with_exit_code;
+  with_xenvmd (fun _ -> run_test_tt_main xenvmd_suite |> check_results_with_exit_code);

--- a/xenvm/lvchange.ml
+++ b/xenvm/lvchange.ml
@@ -3,6 +3,7 @@
 open Cmdliner
 open Lwt
 open Xenvm_common
+open Errors
 
 (* lvchange -a[n|y] /dev/VGNAME/LVNAME *)
 

--- a/xenvm/lvcreate.ml
+++ b/xenvm/lvcreate.ml
@@ -14,6 +14,7 @@ let lvcreate copts lv_name real_size percent_size tags vg_name action =
 
     let extent_size_bytes = Int64.(mul 512L vg.Lvm.Vg.extent_size) in
 
+    (* XXX: Need to guard against integer overflow here *)
     let size = match parse_size real_size percent_size with
     | `Absolute size -> size
     | `Extents extents -> Int64.mul extent_size_bytes extents

--- a/xenvm/pvs.ml
+++ b/xenvm/pvs.ml
@@ -3,6 +3,7 @@
 open Cmdliner
 open Xenvm_common
 open Lwt
+open Errors
 
 let default_fields = [
  "pv_name";

--- a/xenvm/vgs.ml
+++ b/xenvm/vgs.ml
@@ -3,6 +3,7 @@
 open Cmdliner
 open Lwt
 open Xenvm_common
+open Errors
 open Lvm
 module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock)
   

--- a/xenvm/xenvm.ml
+++ b/xenvm/xenvm.ml
@@ -79,6 +79,44 @@ let format config name filenames =
       return () in
   Lwt_main.run t
 
+let upgrade config filename =
+  (* LVM locking code can be seen here:
+   * https://git.fedorahosted.org/cgit/lvm2.git/tree/lib/misc/lvm-flock.c#n141 *)
+  let with_lvm_lock vg_name f =
+    let lock_dir = "/run/lock/lvm" in
+    let lock_path = Filename.concat lock_dir ("V_" ^ vg_name ^ ":aux") in
+    Lwt.catch (fun () ->
+      mkdir_rec lock_dir 0o0700;
+      Lwt_unix.(openfile lock_path [O_CREAT; O_TRUNC; O_RDWR] 0o644)
+      >>= fun fd ->
+      Lwt_unix.(lockf fd F_LOCK) 0;
+    ) (function _ -> fail (Failure "Could_not_obtain_lvm_lock")) >>= fun () ->
+    Lwt.finalize f (fun () -> Lwt_unix.unlink lock_path) in
+  let module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock) in
+  let module Label_IO = Label.Make(Block) in
+  let (>>:=) m f = m >>= function `Ok x -> f x | `Error (`Msg e) -> fail (Failure e) in
+  let t =
+    let (vg_name, _) = parse_name filename in
+    with_lvm_lock vg_name (fun () ->
+      (* Change the label magic to be Journalled to hide from LVM *)
+      with_block filename (fun block ->
+        Label_IO.read block >>:= fun label ->
+        let new_label_header = Label.Label_header.create `Journalled in
+        let new_label = {label with Label.label_header = new_label_header } in
+        Label_IO.write block new_label >>:= fun () ->
+        (* Create the redo log, first reconnect to pick up the label changes *)
+        Vg_IO.connect ~flush_interval:0. [ block ] `RW >>|= fun vg ->
+        let creation_host = Unix.gethostname () in
+        let creation_time = Unix.gettimeofday () |> Int64.of_float in
+        let size = Int64.mul 4L mib in
+        Vg.create (Vg_IO.metadata_of vg) Xenvm_interface._journal_name size
+          ~creation_host ~creation_time >>*= fun (_, op) ->
+        Vg_IO.update vg [ op ] >>|= fun () ->
+        return ()
+      )
+    ) in
+  Lwt_main.run t
+
 let dump config filenames =
     let t =
       let module Vg_IO = Vg.Make(Log)(Block)(Time)(Clock) in
@@ -297,6 +335,15 @@ let format_cmd =
   Term.(pure format $ copts_t $ vgname $ filenames),
   Term.info "format" ~sdocs:copts_sect ~doc ~man
 
+let upgrade_cmd =
+  let doc = "Upgrade the specified VG from LVM2 to XenVM" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Upgrades the volume group metadata so that it will be usable by xenvmd and hidden from lvm."
+  ] in
+  Term.(pure upgrade $ copts_t $ filename),
+  Term.info "upgrade" ~sdocs:copts_sect ~doc ~man
+
 let host_connect_cmd =
   let doc = "Connect to a host" in
   let man = [
@@ -376,6 +423,7 @@ let cmds = [
   Lvresize.lvresize_cmd;
   Lvresize.lvextend_cmd;
   format_cmd;
+  upgrade_cmd;
   dump_cmd;
   shutdown_cmd; host_create_cmd; host_destroy_cmd;
   host_list_cmd;

--- a/xenvm/xenvm_common.ml
+++ b/xenvm/xenvm_common.ml
@@ -16,6 +16,16 @@ let stderr fmt = Printf.ksprintf (fun s ->
   Lwt_log.log ~logger:syslog ~level:Lwt_log.Notice ("stderr:" ^ s)
 ) fmt
 
+let mkdir_rec dir perm =
+  let mkdir_safe dir perm =
+    try Unix.mkdir dir perm with Unix.Unix_error (Unix.EEXIST, _, _) -> () in
+  let rec p_mkdir dir =
+    let p_name = Filename.dirname dir in
+    if p_name <> "/" && p_name <> "."
+    then p_mkdir p_name;
+    mkdir_safe dir perm in
+  p_mkdir dir
+
 module Time = struct
   type 'a io = 'a Lwt.t
   let sleep = Lwt_unix.sleep

--- a/xenvm/xenvm_common.ml
+++ b/xenvm/xenvm_common.ml
@@ -470,15 +470,6 @@ let print_table noheadings header rows =
   then List.map print_row rows
   else print_row header :: (List.map print_row rows)
 
-let (>>*=) m f = match m with
-  | `Error (`Msg e) -> fail (Failure e)
-  | `Error (`DuplicateLV x) -> fail (Failure (Printf.sprintf "%s is a duplicate LV name" x))
-  | `Error (`OnlyThisMuchFree (needed, available)) -> fail (Xenvm_interface.Insufficient_free_space(needed, available))
-  | `Error (`UnknownLV x) -> fail (Failure (Printf.sprintf "I couldn't find an LV named %s" x))
-  | `Ok x -> f x
-
-let (>>|=) m f = m >>= fun x -> x >>*= f
-
 let with_block filename f =
   let open Lwt in
   Block.connect filename


### PR DESCRIPTION
This series adds support for upgrading and downgrading between legacy LVM2 and XenVM VGs. The commands are designed to be idempotent and transactional.
