### PR TITLE
Remove dead code (allocation_quantum in xenvm-local-allocator)

### DIFF
--- a/test.local_allocator.conf.in
+++ b/test.local_allocator.conf.in
@@ -1,6 +1,5 @@
 (
  (socket /tmp/@HOST@-socket)
- (allocation_quantum 16)
  (localJournal @HOST@-localJournal)
  (devices (@BIGDISK@))
  (toLVM @HOST@-toLVM)

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -6,7 +6,6 @@ open Errors
 module Config = struct
   type t = {
     socket: string; (* listen on this socket *)
-    allocation_quantum: int64; (* amount of allocate each device at a time (MiB) *)
     localJournal: string; (* path to the host local journal *)
     devices: string list; (* devices containing the PVs *)
     toLVM: string; (* pending updates for LVM *)


### PR DESCRIPTION
Note: this requires the config files to be changed, otherwise we'll see parse failures. Therefore this should be merged at the same time as an SM patch.
