### PR TITLE
local-allocator: Change calculation of volume size

### DIFF
--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -253,9 +253,8 @@ end
 
 (* Return the virtual size of the volume *)
 let sizeof dm_targets =
-  let open Devmapper in
-  let ends = List.map (fun t -> Int64.add t.Target.start t.Target.size) dm_targets in
-  List.fold_left max 0L ends
+  List.map (fun t -> t.Devmapper.Target.size) dm_targets
+  |> List.fold_left Int64.add 0L
 
 (* Compute the new segments and device mapper targets if [extents] are appended onto [lv] *)
 let extend_volume device vg existing_targets extents =


### PR DESCRIPTION
Before this change the calculation was assuming contiguous target start points.
This assumption was valid but the size of a volume is more simply (and clearly)
retrieved by the sum of the sizes of its targets.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
