### PR TITLE
FreePool Journal fixes

### DIFF
--- a/.travis.oasis
+++ b/.travis.oasis
@@ -60,7 +60,7 @@ Executable "test"
   MainIs:             test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, mirage-block-unix, mirage-clock-unix, devmapper, threads, lvm, lvm.mapper, cstruct, oUnit, io-page, io-page.unix, cmdliner, sexplib.syntax, xenvmidl, shared-block-ring, bisect
+  BuildDepends:       lwt, lwt.unix, lwt.preemptive, mirage-block-unix, mirage-clock-unix, devmapper, threads, lvm, lvm.mapper, cstruct, oUnit, io-page, io-page.unix, cmdliner, sexplib.syntax, xenvmidl, shared-block-ring, bisect
 
 Test xenvm_test
   Command:            ./test.native

--- a/_oasis
+++ b/_oasis
@@ -60,7 +60,7 @@ Executable "test"
   MainIs:             test.ml
   Custom:             true
   Install:            false
-  BuildDepends:       lwt, lwt.unix, mirage-block-unix, mirage-clock-unix, devmapper, threads, lvm, lvm.mapper, cstruct, oUnit, io-page, io-page.unix, cmdliner, sexplib.syntax, xenvmidl, shared-block-ring
+  BuildDepends:       lwt, lwt.unix, lwt.preemptive, mirage-block-unix, mirage-clock-unix, devmapper, threads, lvm, lvm.mapper, cstruct, oUnit, io-page, io-page.unix, cmdliner, sexplib.syntax, xenvmidl, shared-block-ring
 
 Test xenvm_test
   Command:            ./test.native

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 61479b4d37775c46d8e39394432b7989)
+# DO NOT EDIT (digest: b196d31c5b75c3caa9cf12fb8750a776)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -185,6 +185,7 @@ true: annot, bin_annot
 <test/test.{native,byte}>: pkg_lvm
 <test/test.{native,byte}>: pkg_lvm.mapper
 <test/test.{native,byte}>: pkg_lwt
+<test/test.{native,byte}>: pkg_lwt.preemptive
 <test/test.{native,byte}>: pkg_lwt.unix
 <test/test.{native,byte}>: pkg_mirage-block-unix
 <test/test.{native,byte}>: pkg_mirage-clock-unix
@@ -206,6 +207,7 @@ true: annot, bin_annot
 <test/*.ml{,i,y}>: pkg_lvm
 <test/*.ml{,i,y}>: pkg_lvm.mapper
 <test/*.ml{,i,y}>: pkg_lwt
+<test/*.ml{,i,y}>: pkg_lwt.preemptive
 <test/*.ml{,i,y}>: pkg_lwt.unix
 <test/*.ml{,i,y}>: pkg_mirage-block-unix
 <test/*.ml{,i,y}>: pkg_mirage-clock-unix

--- a/idl/config.ml
+++ b/idl/config.ml
@@ -26,3 +26,13 @@ module Xenvmd = struct
   } with sexp
 end
 
+module Local_allocator = struct
+  type t = {
+    socket: string; (* listen on this socket *)
+    allocation_quantum: int64; (* amount of allocate each device at a time (MiB) *)
+    localJournal: string; (* path to the host local journal *)
+    devices: string list; (* devices containing the PVs *)
+    toLVM: string; (* pending updates for LVM *)
+    fromLVM: string; (* received updates from LVM *)
+  } with sexp
+end

--- a/idl/config.ml
+++ b/idl/config.ml
@@ -14,12 +14,15 @@
 open Sexplib.Std
 open Sexplib.Conv
 
-type xenvmd_config = {
-  listenPort: int option; (* TCP port number to listen on *)
-  listenPath: string option; (* path of a unix-domain socket to listen on *)
-  host_allocation_quantum: int64; (* amount of allocate each host at a time (MiB) *)
-  host_low_water_mark: int64; (* when the free memory drops below, we allocate (MiB) *)
-  vg: string; (* name of the volume group *)
-  devices: string list; (* physical device containing the volume group *)
-  rrd_ds_owner: string sexp_option; (* export stats using owner (SR rrd_ds_owner) *)
-} with sexp
+module Xenvmd = struct
+  type t = {
+    listenPort: int option; (* TCP port number to listen on *)
+    listenPath: string option; (* path of a unix-domain socket to listen on *)
+    host_allocation_quantum: int64; (* amount of allocate each host at a time (MiB) *)
+    host_low_water_mark: int64; (* when the free memory drops below, we allocate (MiB) *)
+    vg: string; (* name of the volume group *)
+    devices: string list; (* physical device containing the volume group *)
+    rrd_ds_owner: string sexp_option; (* export stats using owner (SR rrd_ds_owner) *)
+  } with sexp
+end
+

--- a/setup.sh
+++ b/setup.sh
@@ -57,7 +57,18 @@ sleep 2
 cat test.local_allocator.conf.in | sed -r "s|@BIGDISK@|$LOOP|g"  | sed -r "s|@HOST@|host1|g" > test.local_allocator.host1.conf
 ./local_allocator.native --config ./test.local_allocator.host1.conf $MOCK_ARG > local_allocator.host1.log &
 
-sleep 30 # the local allocator daemonizes too soon
+./xenvm.native host-disconnect /dev/djstest host1 --configdir /tmp/xenvm.d $MOCK_ARG
+./xenvm.native host-connect /dev/djstest host1 --configdir /tmp/xenvm.d $MOCK_ARG
+./local_allocator.native --config ./test.local_allocator.host1.conf $MOCK_ARG > local_allocator.host1.log2 &
+
+for ((i=0; i<10; i++)); do
+  ./xenvm.native host-disconnect /dev/djstest host1 --configdir /tmp/xenvm.d $MOCK_ARG
+  ./xenvm.native host-connect /dev/djstest host1 --configdir /tmp/xenvm.d $MOCK_ARG
+  ./local_allocator.native --config ./test.local_allocator.host1.conf $MOCK_ARG > local_allocator.host1.log3 &
+done
+
+
+sleep 20
 
 ./xenvm.native lvextend /dev/djstest/live -L 128M --live --configdir /tmp/xenvm.d $MOCK_ARG
 

--- a/test/common.ml
+++ b/test/common.ml
@@ -255,3 +255,10 @@ let xenvm = function
     let args = if !use_mock then "--mock-devmapper" :: "--configdir" :: "/tmp/xenvm.d" :: args else args in
     run "./xenvm.native" (cmd :: args)
 let xenvmd = run "./xenvmd.native"
+let local_allocator =
+  let cmd = "./local_allocator.native" in
+  function
+  | [] -> run cmd []
+  | args ->
+    let args = if !use_mock then args @ ["--mock-devmapper"] else args in
+    run cmd args

--- a/test/common.ml
+++ b/test/common.ml
@@ -18,7 +18,7 @@ open Vg
 open Lwt
 
 (* Mock kernel devices so we can run as a regular user *)
-let use_mock = ref false
+let use_mock = ref true
 
 module Time = struct
   type 'a io = 'a Lwt.t

--- a/test/common.ml
+++ b/test/common.ml
@@ -18,7 +18,7 @@ open Vg
 open Lwt
 
 (* Mock kernel devices so we can run as a regular user *)
-let use_mock = ref true
+let use_mock = ref false
 
 module Time = struct
   type 'a io = 'a Lwt.t
@@ -97,6 +97,32 @@ let rm_f x =
    with _ ->
     debug "%s already deleted" x;
     ()
+
+exception InsanityDetected of string * string
+
+let sanity_check vg =
+  Printf.printf "In sanity_check. size of vg.Lvm.Vg.lvs = %d\n%!" (Lvm.Vg.LVs.cardinal vg.Lvm.Vg.lvs);
+  let allocations =
+    Lvm.Vg.LVs.fold (fun k v acc ->
+        let allocation = Lvm.Lv.to_allocation v in
+        Printf.printf "LV: %s\nAllocation:\n%s\n%!" v.Lvm.Lv.name (Lvm.Pv.Allocator.to_string allocation);
+        (v.Lvm.Lv.name, allocation) :: acc) vg.Lvm.Vg.lvs []
+  in
+  let rec check allocations =
+    match allocations with
+    | (name, alloc) :: rest ->
+      List.iter
+          (fun (name', alloc') ->
+             let open Lvm.Pv.Allocator in
+             let size1 = size alloc in
+             let size2 = size alloc' in
+             let merged = merge alloc alloc' in
+             let size3 = size merged in
+             let diff = Int64.(sub (add size1 size2) size3) in
+             if diff <> 0L then raise (InsanityDetected (name, name'))) rest;
+      check rest
+    | _ -> ()
+  in check allocations
 
 (* From Xcp_service: *)
 let colon = Re_str.regexp_string ":"
@@ -249,10 +275,16 @@ let with_block filename f =
   | `Ok x ->
     f x (* no point catching errors here *)
 
-let xenvm = function
+let get_configdir host =
+  Printf.sprintf "/tmp/xenvm.host%d.d" host
+
+let xenvm ?(host=1) args =
+  let configdir = get_configdir host in
+  match args with
   | [] -> run "./xenvm.native" []
   | cmd :: args ->
-    let args = if !use_mock then "--mock-devmapper" :: "--configdir" :: "/tmp/xenvm.d" :: args else args in
+    let args = "--configdir" :: configdir :: args in
+    let args = if !use_mock then "--mock-devmapper" :: args else args in
     run "./xenvm.native" (cmd :: args)
 let xenvmd = run "./xenvmd.native"
 let local_allocator =

--- a/test/test.ml
+++ b/test/test.ml
@@ -407,7 +407,10 @@ let la_start device =
              let la_thread = start_local_allocator "host1" [device] in
              ignore(xenvm ["host-disconnect"; vg; "host1"]);
              Lwt.choose [la_thread; (Lwt_unix.sleep 30.0 >>= fun () -> Lwt.fail Timeout)]
-             >>= fun _ ->
+             >>= fun log ->
+             Lwt_io.(with_file output (Printf.sprintf "local_allocator.%d.log" n)
+               (fun chan -> write chan log))
+             >>= fun () ->
              n_times (n-1)
            end
          in

--- a/test/test.ml
+++ b/test/test.ml
@@ -515,4 +515,6 @@ let _ =
     then exit 1 in
   run_test_tt_main no_xenvmd_suite |> check_results_with_exit_code;
   with_xenvmd (fun _ _ -> run_test_tt_main xenvmd_suite |> check_results_with_exit_code);
-  with_xenvmd (fun _ device -> run_test_tt_main (local_allocator_suite device) |> check_results_with_exit_code)
+  if not !Common.use_mock then begin (* FIXME: #99 *)
+    with_xenvmd (fun _ device -> run_test_tt_main (local_allocator_suite device) |> check_results_with_exit_code)
+  end

--- a/test/test.ml
+++ b/test/test.ml
@@ -51,7 +51,7 @@ let with_xenvmd ?existing_vg ?(cleanup_vg=true) (f : string -> 'a) =
   let with_xenvmd_running loop =
       xenvm [ "set-vg-info"; "--pvpath"; loop; "-S"; "/tmp/xenvmd"; vg; "--local-allocator-path"; "/tmp/xenvm-local-allocator"; "--uri"; "file://local/services/xenvmd/"^vg ] |> ignore_string;
       let config = {
-        Config.listenPort = None;
+        Config.Xenvmd.listenPort = None;
         listenPath = Some "/tmp/xenvmd";
         host_allocation_quantum = 128L;
         host_low_water_mark = 8L;
@@ -59,7 +59,7 @@ let with_xenvmd ?existing_vg ?(cleanup_vg=true) (f : string -> 'a) =
         devices = [loop];
         rrd_ds_owner = Some (Printf.sprintf "xenvmd-%d-stats" (Unix.getpid ()));
       } in
-      Sexplib.Sexp.to_string_hum (Config.sexp_of_xenvmd_config config)
+      Sexplib.Sexp.to_string_hum (Config.Xenvmd.sexp_of_t config)
       |> file_of_string "test.xenvmd.conf";
       xenvmd [ "--config"; "./test.xenvmd.conf"; "--daemon" ] |> ignore_string;
       Xenvm_client.Rpc.uri := "file://local/services/xenvmd/" ^ vg;

--- a/xenvmd/volumeManager.ml
+++ b/xenvmd/volumeManager.ml
@@ -751,9 +751,10 @@ module FreePool = struct
           connected_host.free_LV size_mib config.host_low_water_mark;
         match !journal with
         | Some j ->
+          let open Op in
           J.push j
-            (Op.FreeAllocation
-               Op.{ host;
+            (FreeAllocation
+               { host;
                     old_allocation=Lvm.Lv.to_allocation lv;
                     extra_size=config.host_allocation_quantum })
           >>|= fun wait ->

--- a/xenvmd/volumeManager.mli
+++ b/xenvmd/volumeManager.mli
@@ -10,8 +10,8 @@ end
 module FreePool : sig
   val start : string -> unit Lwt.t
   val shutdown : unit -> unit Lwt.t
-  val resend_free_volumes : Config.xenvmd_config -> unit Lwt.t
-  val top_up_free_volumes : Config.xenvmd_config -> unit Lwt.t
+  val resend_free_volumes : Config.Xenvmd.t -> unit Lwt.t
+  val top_up_free_volumes : Config.Xenvmd.t -> unit Lwt.t
 end
 
 val vgopen : devices:string list -> unit Lwt.t


### PR DESCRIPTION
Fixes a problem where 2 hosts could get allocated the same extents for their free pools, and also starts to fix a problem where the incomplete flushing of the FreePool journal could result in the local allocator getting duplicated extents from which it allocates, leading to corruption.
