### PR TITLE
CA-173691: Local allocator should handle connections disappearing

### DIFF
--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -543,6 +543,7 @@ let mock_dm_arg =
   Arg.(value & flag & info ["mock-devmapper"] ~doc)
 
 let () =
+  Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
   let t = Term.(pure main $ mock_dm_arg $ config $ daemon $ socket $ journal $ fromLVM $ toLVM) in
   match Term.eval (t, info) with
   | `Error _ -> exit 1

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -472,9 +472,8 @@ let main use_mock config daemon socket journal fromLVM toLVM =
     Lwt_unix.bind s (Lwt_unix.ADDR_UNIX(config.socket));
     Lwt_unix.listen s 5;
     let conn_handler fd () =
-      let ic = Lwt_io.of_fd ~mode:Lwt_io.input fd in
-      let oc = Lwt_io.of_fd ~mode:Lwt_io.output ~close:return fd in
-      (* read one line *)
+      let ic = Lwt_io.of_fd ~mode:Lwt_io.input ~close:return fd in
+      let oc = Lwt_io.of_fd ~mode:Lwt_io.output fd in
       Lwt_io.read_line ic
       >>= fun message ->
       let r = ResizeRequest.t_of_sexp (Sexplib.Sexp.of_string message) in
@@ -482,10 +481,7 @@ let main use_mock config daemon socket journal fromLVM toLVM =
       >>= fun resp ->
       Lwt_io.write_line oc (Sexplib.Sexp.to_string (ResizeResponse.sexp_of_t resp))
       >>= fun () ->
-      Lwt_io.flush oc
-      >>= fun () ->
-      Lwt_io.close ic
-    in
+      Lwt_io.close oc in
     let rec unix () =
       debug "Calling accept on the socket";
       Lwt_unix.accept s


### PR DESCRIPTION
If a request is made to the local allocator on its socket but the requester goes away before waiting for a response then the local allocator would die because it would get a SIGPIPE when it tried to flush its output. It should gracefully handle this and continue to service other requests.
