### PR TITLE
Daemonizeing bits

### DIFF
--- a/idl/daemon.ml
+++ b/idl/daemon.ml
@@ -1,0 +1,48 @@
+(* This function is largely taken from the Lwt_daemon module, but extended
+   such that the parent process will wait until the child confirms it has
+   completely set up correctly *)
+
+let daemonize () =
+  Unix.chdir "/";
+
+  (* The input end of the pipe is handled by the parent, which will
+     read the exit code from it. the output end is given to the 
+     child, which will write the exit code when it knows what it should
+     be. *)
+  let ic,oc = Lwt_io.pipe () in
+  
+  (* Exit the parent, and continue in the child: *)
+  if Lwt_unix.fork () > 0 then begin
+    (* Do not run exit hooks in the parent. *)
+    Lwt_sequence.iter_node_l Lwt_sequence.remove Lwt_main.exit_hooks;
+    let open Lwt.Infix in
+    let t =
+      Lwt_io.read_line ic >>= fun exitcode ->
+      let exitcode = int_of_string exitcode in
+      exit exitcode in
+    Lwt_main.run t
+  end;
+    
+  (* Redirection of standard IOs *)
+  let dev_null = Unix.openfile "/dev/null" [Unix.O_RDWR] 0o666 in
+  
+  Unix.dup2 dev_null Unix.stdin;
+  Unix.dup2 dev_null Unix.stdout;
+  Unix.dup2 dev_null Unix.stderr;
+  
+  Unix.close dev_null;
+  
+  ignore (Unix.umask 0o022);
+  
+  ignore (Unix.setsid ());
+
+  oc
+    
+
+let parent_should_exit oc n =
+  match oc with
+  | Some oc ->
+    Lwt_io.write_line oc (Printf.sprintf "%d\n" n)
+  | None ->
+    Lwt.return ()
+    

--- a/idl/pidfile.ml
+++ b/idl/pidfile.ml
@@ -6,9 +6,7 @@ let write_pid pidfile =
     let fd = Unix.openfile pidfile [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o0644 in
     Unix.lockf fd Unix.F_TLOCK (String.length txt);
     let (_: int) = Unix.write fd txt 0 (String.length txt) in
-    ()
+    `Ok ()
   with e ->
-    Printf.fprintf stderr "%s\n" (Printexc.to_string e);
-    Printf.fprintf stderr "The pidfile %s is locked: you cannot start the program twice!\n" pidfile;
-    Printf.fprintf stderr "If the process was shutdown cleanly then verify and remove the pidfile.\n%!";
-    exit 1
+    `Error (`Msg (Printexc.to_string e))
+

--- a/idl/pidfile.ml
+++ b/idl/pidfile.ml
@@ -3,10 +3,15 @@
 let write_pid pidfile =
   let txt = string_of_int (Unix.getpid ()) in
   try
-    let fd = Unix.openfile pidfile [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o0644 in
-    Unix.lockf fd Unix.F_TLOCK (String.length txt);
-    let (_: int) = Unix.write fd txt 0 (String.length txt) in
-    `Ok ()
-  with e ->
-    `Error (`Msg (Printexc.to_string e))
-
+    begin
+      let fd = Unix.openfile pidfile [ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC ] 0o0644 in
+      try
+        Unix.lockf fd Unix.F_TLOCK (String.length txt);
+        let (_: int) = Unix.write fd txt 0 (String.length txt) in
+        `Ok fd
+      with e ->
+        Unix.close fd;
+        `Error (`Msg (Printexc.to_string e))
+    end
+  with
+  e -> `Error (`Msg (Printexc.to_string e))

--- a/test/common.ml
+++ b/test/common.ml
@@ -40,9 +40,9 @@ let ignore_string (_: string) = ()
 let log fmt =
   Printf.ksprintf
     (fun s ->
-      output_string stderr s;
-      output_string stderr "\n";
-      flush stderr;
+      output_string stdout s;
+      output_string stdout "\n";
+      flush stdout;
       ) fmt
 let debug fmt = log fmt
 let warn fmt = debug fmt
@@ -151,7 +151,10 @@ let canonicalise x =
 
 exception Bad_exit of int * string * string list * string * string
 
+let times = ref []
+
 let run ?(env= Unix.environment()) ?stdin cmd args =
+  let starttime = Unix.gettimeofday () in
   let cmd = canonicalise cmd in
   debug "%s %s" cmd (String.concat " " args);
   let null = Unix.openfile "/dev/null" [ Unix.O_RDWR ] 0 in
@@ -206,9 +209,15 @@ let run ?(env= Unix.environment()) ?stdin cmd args =
 
     let _, status = Unix.waitpid [] pid in
 
+    let completed = Unix.gettimeofday () in
+
     let stdout = read_all stdout_readable in
     let stderr = read_all stderr_readable in    
     close_all ();
+    debug "done (%s %s - %f)" cmd (String.concat " " args) (completed -. starttime);
+    let cmd = Printf.sprintf "%s %s" cmd (String.concat " " args) in
+    let time = completed -. starttime in
+    times := (time, cmd)::(!times);
 
     match status with
     | Unix.WEXITED 0 ->
@@ -220,6 +229,11 @@ let run ?(env= Unix.environment()) ?stdin cmd args =
   with e ->
     close_all ();
     raise e
+
+
+let dump_stats () =
+  let stats = List.sort (fun (t1,_) (t2,_) -> compare t1 t2) !times in
+  List.iter (fun (time,cmd) -> Printf.printf "%f: %s\n" time cmd) stats
 
 module Int64 = struct
   include Int64

--- a/test/test.ml
+++ b/test/test.ml
@@ -107,9 +107,8 @@ let start_local_allocator host devices =
   } in
   Sexplib.Sexp.to_string_hum (Config.Local_allocator.sexp_of_t config)
   |> file_of_string config_file;
-  let local_allocator_thread = Lwt_preemptive.detach local_allocator [ "--config"; config_file; ] in
   ignore(xenvm [ "host-connect"; vg; hostname]);
-  local_allocator_thread
+  ignore(local_allocator [ "--config"; config_file; "--daemon"])
 
 let lvchange_offline =
   "lvchange vg/lv --offline: check that we can activate volumes offline" >::
@@ -431,18 +430,32 @@ let xenvmd_suite = "Commands which require xenvmd" >::: [
 
 exception Timeout
 
+let la_is_running host =
+  let pidfile = Printf.sprintf "%s.lock" (get_local_allocator_sockpath host) in
+  match Pidfile.write_pid pidfile with
+  | `Ok fd ->
+    (* It clearly wasn't running, as we've got the lock *)
+    Unix.close fd;
+    Unix.unlink pidfile;
+    false
+  | `Error _ ->
+    (* It's still running *)
+    true
+
+let rec wait_la_stop host =
+  if la_is_running host then
+    Lwt_unix.sleep 0.1 >>= fun () -> wait_la_stop host
+  else Lwt.return ()
+
 let la_start device =
   "Start and shutdown the local allocator" >::
   (fun () ->
      ignore(Lwt_main.run (
          let rec n_times n =
            if n=0 then Lwt.return () else begin
-             let la_thread = start_local_allocator 1 [device] in
+             start_local_allocator 1 [device];
              ignore(xenvm ["host-disconnect"; vg; "host1"]);
-             Lwt.choose [la_thread; (Lwt_unix.sleep 30.0 >>= fun () -> Lwt.fail Timeout)]
-             >>= fun log ->
-             Lwt_io.(with_file output (Printf.sprintf "local_allocator.%d.log" n)
-               (fun chan -> write chan log))
+             Lwt.choose [wait_la_stop 1; (Lwt_unix.sleep 30.0 >>= fun () -> Lwt.fail Timeout)]
              >>= fun () ->
              n_times (n-1)
            end
@@ -455,11 +468,10 @@ let la_extend device =
   (fun () ->
      ignore(Lwt_main.run (
          let lvname = "test" in
-         let la_thread = start_local_allocator 1 [device] in
-         Lwt_unix.sleep 20.0 >>= fun () ->
+         start_local_allocator 1 [device];
          ignore(xenvm ["lvcreate"; "-n"; lvname; "-L"; "4"; vg]);
          ignore(xenvm ["lvextend"; "-L"; "132"; "--live"; Printf.sprintf "%s/%s" vg lvname]);
-         Lwt_unix.sleep 15.0 >>= fun () ->
+         Lwt_unix.sleep 11.0 >>= fun () ->
          Client.get_lv lvname >>= fun (myvg, lv) ->
          ignore(myvg,lv);
          let size = Lvm.Lv.size_in_extents lv in
@@ -467,10 +479,12 @@ let la_extend device =
          assert_equal ~msg:"Unexpected final size"
            ~printer:Int64.to_string 31L size;
          ignore(xenvm ["host-disconnect"; vg; "host1"]);
-         Lwt.choose [la_thread; (Lwt_unix.sleep 30.0 >>= fun () -> Lwt.fail Timeout)]
-         >>= fun log ->
-         Lwt_io.(with_file output "local_allocator.log"
-                   (fun chan -> write chan log)))))
+         Lwt.choose [wait_la_stop 1; (Lwt_unix.sleep 30.0 >>= fun () -> Lwt.fail Timeout)])))
+
+let inparallel fns =
+  Lwt.join (
+    List.map (fun fn ->
+        Lwt_preemptive.detach (fun () -> ignore(fn ())) ()) fns)
 
 let la_extend_multi device =
   "Extend an LV with the local allocator" >::
@@ -478,16 +492,18 @@ let la_extend_multi device =
      ignore(Lwt_main.run (
          let lvname = "test2" in
          let lvname2 = "test3" in
-         let la_thread = start_local_allocator 1 [device] in
-         Lwt_unix.sleep 10.0 >>= fun () ->
-         let la_thread2 = start_local_allocator 2 [device] in
+         start_local_allocator 1 [device];
+         start_local_allocator 2 [device];
          set_vg_info device vg 2;
-         Lwt_unix.sleep 20.0 >>= fun () ->
-         ignore(xenvm ["lvcreate"; "-n"; lvname; "-L"; "4"; vg]);
-         ignore(xenvm ["lvcreate"; "-n"; lvname2; "-L"; "4"; vg]);
-         ignore(xenvm ["lvextend"; "-L"; "132"; "--live"; Printf.sprintf "%s/%s" vg lvname]);
-         ignore(xenvm ~host:2 ["lvextend"; "-L"; "132"; "--live"; Printf.sprintf "%s/%s" vg lvname2]);
-         Lwt_unix.sleep 15.0 >>= fun () ->
+         inparallel [(fun () -> xenvm ["lvcreate"; "-n"; lvname; "-L"; "4"; vg]);
+                     (fun () -> xenvm ["lvcreate"; "-n"; lvname2; "-L"; "4"; vg])]
+         >>= fun () ->
+         inparallel [(fun () -> xenvm ["lvextend"; "-L"; "132"; "--live"; Printf.sprintf "%s/%s" vg lvname]);
+                     (fun () -> xenvm ~host:2 ["lvextend"; "-L"; "132"; "--live"; Printf.sprintf "%s/%s" vg lvname2])]
+         >>= fun () ->
+         inparallel [(fun () -> xenvm ["host-disconnect"; vg; "host1"] |> ignore);
+                     (fun () -> xenvm ["host-disconnect"; vg; "host2"] |> ignore)]
+         >>= fun () ->
          Client.get_lv lvname >>= fun (myvg, lv) ->
          Client.get_lv lvname2 >>= fun (_, lv2) ->
          ignore(myvg,lv,lv2);
@@ -503,18 +519,9 @@ let la_extend_multi device =
            ~printer:Int64.to_string 33L size;
                   assert_equal ~msg:"Unexpected final size"
            ~printer:Int64.to_string 33L size2;
-         ignore(xenvm ["host-disconnect"; vg; "host1"]);
-         ignore(xenvm ["host-disconnect"; vg; "host2"]);
-         let la_dead = la_thread >>= fun _ -> la_thread2 in
+
+         let la_dead = wait_la_stop 1 >>= fun _ -> wait_la_stop 2 in
          Lwt.choose [la_dead; (Lwt_unix.sleep 30.0 >>= fun () -> Lwt.fail Timeout)]
-         >>= fun _ ->
-         la_thread >>= fun log ->
-         Lwt_io.(with_file output "local_allocator.log"
-                   (fun chan -> write chan log))
-         >>= fun _ ->
-         la_thread2 >>= fun log ->
-         Lwt_io.(with_file output "local_allocator2.log"
-                   (fun chan -> write chan log))
        )))
 
 let local_allocator_suite device = "Commands which require the local allocator" >::: [
@@ -533,4 +540,5 @@ let _ =
   with_xenvmd (fun _ _ -> run_test_tt_main xenvmd_suite |> check_results_with_exit_code);
   if not !Common.use_mock then begin (* FIXME: #99 *)
     with_xenvmd (fun _ device -> run_test_tt_main (local_allocator_suite device) |> check_results_with_exit_code)
-  end
+  end;
+  dump_stats ()

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -223,7 +223,15 @@ let main use_mock config daemon socket journal fromLVM toLVM =
 
   let module D = (val !dm: Devmapper.S.DEVMAPPER) in
 
-  if daemon then Lwt_daemon.daemonize ();
+  let oc =
+    if daemon
+    then
+      begin
+        Lwt_log.default := Lwt_log.syslog ~facility:`Daemon ();
+        Some (Daemon.daemonize ())
+      end
+    else None
+  in
 
   let t =
     debug "Loaded configuration: %s" (Sexplib.Sexp.to_string_hum (sexp_of_t config))
@@ -438,6 +446,9 @@ let main use_mock config daemon socket journal fromLVM toLVM =
       async (conn_handler fd);
       unix () in
     let listen_unix = unix () in
+    (* At this point, we ask our parent to exit *)
+    Daemon.parent_should_exit oc 0
+    >>= fun () ->
     debug "Waiting forever for requests"
     >>= fun () ->
     Lwt.join (listen_unix :: (if daemon then [] else [ stdin () ]))
@@ -445,10 +456,15 @@ let main use_mock config daemon socket journal fromLVM toLVM =
     debug "Stopped listening"
     >>= fun () ->
     return () in
+
   try
     `Ok (Lwt_main.run t)
   with Failure msg ->
-    Lwt_main.run (error "%s" msg);
+    Lwt_main.run (
+      error "%s" msg
+      >>= fun () ->
+      Daemon.parent_should_exit oc 1
+    );
     `Error(false, msg)
 
 open Cmdliner

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -225,10 +225,20 @@ let main use_mock config daemon socket journal fromLVM toLVM =
 
   if daemon then Lwt_daemon.daemonize ();
 
-  Pidfile.write_pid (config.socket ^ ".lock");
-
   let t =
     debug "Loaded configuration: %s" (Sexplib.Sexp.to_string_hum (sexp_of_t config))
+    >>= fun () ->
+
+    begin
+      let pidfile = config.socket ^ ".lock" in
+      match Pidfile.write_pid pidfile with
+      | `Ok () -> Lwt.return ()
+      | `Error (`Msg msg) ->
+        Log.error "Caught exception while writing pidfile: %s" msg >>= fun () ->
+        Log.error "The pidfile %s is locked: you cannot start the program twice!" pidfile >>= fun () ->
+        Log.error "If the process was shutdown cleanly then verify and remove the pidfile." >>= fun () ->
+        exit 1
+    end
     >>= fun () ->
 
     Device.read_sector_size config.devices

--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -219,6 +219,8 @@ let main use_mock config daemon socket journal fromLVM toLVM =
     fromLVM = (match fromLVM with None -> config.fromLVM | Some x -> x);
   } in
 
+  Lwt_log.add_rule "*" Lwt_log.Debug;
+
   dm := if use_mock then (module Devmapper.Mock: Devmapper.S.DEVMAPPER) else (module Devmapper.Linux: Devmapper.S.DEVMAPPER);
 
   let module D = (val !dm: Devmapper.S.DEVMAPPER) in
@@ -234,13 +236,14 @@ let main use_mock config daemon socket journal fromLVM toLVM =
   in
 
   let t =
+    info "Starting local allocator thread" >>= fun () ->
     debug "Loaded configuration: %s" (Sexplib.Sexp.to_string_hum (sexp_of_t config))
     >>= fun () ->
 
     begin
       let pidfile = config.socket ^ ".lock" in
       match Pidfile.write_pid pidfile with
-      | `Ok () -> Lwt.return ()
+      | `Ok _ -> Lwt.return ()
       | `Error (`Msg msg) ->
         Log.error "Caught exception while writing pidfile: %s" msg >>= fun () ->
         Log.error "The pidfile %s is locked: you cannot start the program twice!" pidfile >>= fun () ->

--- a/xenvm/lvremove.ml
+++ b/xenvm/lvremove.ml
@@ -9,8 +9,9 @@ let lvremove copts (vg_name,lv_opt) force =
   Lwt_main.run (
     get_vg_info_t copts vg_name >>= fun info ->
     set_uri copts info;
-    Client.get () >>= fun vg ->
+    Client.get_lv ~name:lv_name >>= fun (vg, lv) ->
     if vg.Lvm.Vg.name <> vg_name then failwith "Invalid VG name";
+    Lvchange.deactivate vg lv >>= fun _ ->
     Client.remove lv_name)
 
 let lvremove_cmd =

--- a/xenvmd/xenvmd.ml
+++ b/xenvmd/xenvmd.ml
@@ -109,7 +109,7 @@ let maybe_write_pid config =
     >>= fun () ->
     begin
       match Pidfile.write_pid pidfile with
-      | `Ok () ->
+      | `Ok _ ->
         Lwt.return ()
       | `Error (`Msg msg) ->
         Log.error "Caught exception while writing pidfile: %s" msg >>= fun () ->
@@ -253,6 +253,7 @@ let main port sock_path config daemon =
   let config = t_of_sexp (Sexplib.Sexp.load_sexp config) in
   let config = { config with listenPort = match port with None -> config.listenPort | Some x -> Some x } in
   let config = { config with listenPath = match sock_path with None -> config.listenPath | Some x -> Some x } in
+  Lwt_log.add_rule "*" Lwt_log.Debug;
 
   if daemon then daemonize config;
 

--- a/xenvmd/xenvmd.ml
+++ b/xenvmd/xenvmd.ml
@@ -104,10 +104,19 @@ let maybe_write_pid config =
       (* don't need a lock file because we'll fail to bind to the port *)
     Lwt.return ()
   | Some path ->
-    info "Writing pidfile to %s" path
+    let pidfile = path ^ ".lock" in
+    info "Writing pidfile to %s" pidfile
     >>= fun () ->
-    Pidfile.write_pid (path ^ ".lock");
-    Lwt.return ()
+    begin
+      match Pidfile.write_pid pidfile with
+      | `Ok () ->
+        Lwt.return ()
+      | `Error (`Msg msg) ->
+        Log.error "Caught exception while writing pidfile: %s" msg >>= fun () ->
+        Log.error "The pidfile %s is locked: you cannot start the program twice!" pidfile >>= fun () ->
+        Log.error "If the process was shutdown cleanly then verify and remove the pidfile." >>= fun () ->
+        exit 1
+    end
 
 let run port sock_path config =
   let t =


### PR DESCRIPTION
When running in daemon mode, the parent local allocator process doesn't exit until the child is ready to handle the connection.

Also fixes CA-173633, where the device-mapper node wasn't removed on lvremove
