### PR TITLE
CA-185666: Handle fragmented expands again

### DIFF
--- a/xenvm-local-allocator/local_allocator.ml
+++ b/xenvm-local-allocator/local_allocator.ml
@@ -349,8 +349,9 @@ let main use_mock config daemon socket journal fromLVM toLVM =
         Lwt_mutex.with_lock m
           (fun () ->
              (* We may need to enlarge in multiple chunks if the free pool is depleted *)
-            D.stat device >>= fun s ->
-            let rec expand action = match s with
+            let rec expand action =
+              D.stat device >>= fun s ->
+              match s with
               | None ->
                 (* Log this kind of error. This tapdisk may block but at least
                    others will keep going *)


### PR DESCRIPTION
The local allocator needs to stat the device to find out where to put the new
extents. If it has less extents than the extend request then it needs to
re-stat the device after partially fulfilling the request to ensure the second
part is put after the first and not overlapping.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
