### PR TITLE
travis: use trusty (to satisfy `ocaml-xen-lowlevel-libs` >= 0.9.30)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
 script: cp .travis.oasis _oasis && bash -ex .travis-opam.sh && bash -ex .travis.sh
 sudo: true
+dist: trusty
 env:
   global:
     - PACKAGE=thin_lvhd_tools


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@unikernel.com
